### PR TITLE
UPDATE: Add markdown support for reply.

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import openai
+import markdown
 from flask import Flask, redirect, render_template, request, url_for
 
 app = Flask(__name__)
@@ -53,6 +54,9 @@ def chat():
     reply = completion.choices[0]['message']['content']  # type: ignore
 
     message_list.append({"role": "assistant", "content": reply})
+
+    # 将回复结果 Markdown 处理
+    reply = markdown.markdown(reply)
 
     # 将回复添加到聊天历史中
     chat_history.append((message, reply))

--- a/templates/chat.html.jinja2
+++ b/templates/chat.html.jinja2
@@ -54,6 +54,8 @@
     <!-- Include highlight.js -->
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/styles/default.min.css">
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/highlight.min.js"></script>
+    <!-- Include markdown-it.js -->
+    <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
ChatGPT 本身具备了良好的 markdown 支持，但是在原先的版本中，所有的 markdown 输出结果均不被正常显示，故引入了 python markdown 包以及 markdown-it.js 以支持 Markdown 显示。

可能存在一些问题，请多多批评（